### PR TITLE
feat!: change to protobuf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Main CI
+
+on: pull_request
+
+jobs:
+  all-status-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - buf-check
+    steps:
+      - name: All status check
+        run: echo "All status check passed"
+
+  buf-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@d4b43256b3a511e94e6c0d38d478e1bd39f8690e # V1.0.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
       - buf-check
     steps:
       - name: All status check
-        run: echo "All status check passed"
+        run: echo "All status checks passed"
+        
 
   buf-check:
     runs-on: ubuntu-latest

--- a/belifeline/models/v1/extinfo.proto
+++ b/belifeline/models/v1/extinfo.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package belifeline.models.v1;
+
+import "belifeline/models/v1/types.proto";
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+// ExtInfo Messages
+message ExampleInfoExampleData {
+  MultiPolygon area = 1;
+  bytes image = 2;
+}
+
+message ExternalInformation {
+  UUID external_id = 1;
+  string external_name = 2;
+  string external_description = 3;
+  string license = 4;
+  string license_description = 5;
+  string first_entry_at = 6;
+  string last_updated_at = 7;
+  repeated string updated_history = 8;
+}

--- a/belifeline/models/v1/extinfo.proto
+++ b/belifeline/models/v1/extinfo.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package belifeline.models.v1;
 
 import "belifeline/models/v1/types.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
@@ -18,7 +19,7 @@ message ExternalInformation {
   string external_description = 3;
   string license = 4;
   string license_description = 5;
-  string first_entry_at = 6;
-  string last_updated_at = 7;
+  google.protobuf.Timestamp first_entry_at = 6;
+  google.protobuf.Timestamp last_updated_at = 7;
   repeated string updated_history = 8;
 }

--- a/belifeline/models/v1/koyo.proto
+++ b/belifeline/models/v1/koyo.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package belifeline.models.v1;
 
 import "belifeline/models/v1/types.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
@@ -11,8 +12,8 @@ message KoyoData {
   UUID koyo_id = 2;
   float koyo_scale = 3;
   bytes content = 4;
-  string entry_at = 5;
-  string target_at = 6;
+  google.protobuf.Timestamp entry_at = 5;
+  google.protobuf.Timestamp target_at = 6;
 }
 
 message KoyoDataCreate {
@@ -34,7 +35,7 @@ message KoyoInformation {
   string license = 10;
   repeated string ext_licenses = 11;
   DataType data_type = 12;
-  string first_entry_at = 13;
-  string last_entry_at = 14;
-  string last_updated_at = 15;
+  google.protobuf.Timestamp first_entry_at = 13;
+  google.protobuf.Timestamp last_entry_at = 14;
+  google.protobuf.Timestamp last_updated_at = 15;
 }

--- a/belifeline/models/v1/koyo.proto
+++ b/belifeline/models/v1/koyo.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package belifeline.models.v1;
+
+import "belifeline/models/v1/types.proto";
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+message KoyoData {
+  string koyo_data_id = 1;
+  UUID koyo_id = 2;
+  float koyo_scale = 3;
+  bytes content = 4;
+  string entry_at = 5;
+  string target_at = 6;
+}
+
+message KoyoDataCreate {
+  UUID koyo_id = 1;
+  float koyo_scale = 2;
+  bytes content = 3;
+}
+
+message KoyoInformation {
+  UUID koyo_id = 1;
+  string koyo_name = 2;
+  string koyo_description = 3;
+  repeated UUID need_external = 4;
+  map<string, string> koyo_params = 5;
+  repeated float koyo_scales = 6;
+  repeated UUID koyo_data_ids = 7;
+  Version version = 8;
+  repeated Version version_history = 9;
+  string license = 10;
+  repeated string ext_licenses = 11;
+  DataType data_type = 12;
+  string first_entry_at = 13;
+  string last_entry_at = 14;
+  string last_updated_at = 15;
+}

--- a/belifeline/models/v1/provider.proto
+++ b/belifeline/models/v1/provider.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package belifeline.models.v1;
+
+import "belifeline/models/v1/types.proto";
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+message ClientData {
+  UUID client_id = 1;
+  string username = 2;
+  ApiKey api_key = 3;
+  string created_at = 4;
+  string last_used_at = 5;
+  string last_updated_at = 6;
+}

--- a/belifeline/models/v1/provider.proto
+++ b/belifeline/models/v1/provider.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package belifeline.models.v1;
 
 import "belifeline/models/v1/types.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
@@ -10,7 +11,7 @@ message ClientData {
   UUID client_id = 1;
   string username = 2;
   ApiKey api_key = 3;
-  string created_at = 4;
-  string last_used_at = 5;
-  string last_updated_at = 6;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp last_used_at = 5;
+  google.protobuf.Timestamp last_updated_at = 6;
 }

--- a/belifeline/models/v1/types.proto
+++ b/belifeline/models/v1/types.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package belifeline.models.v1;
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+// Common Types
+message DateUntil {
+  string before = 1;
+  string after = 2;
+}
+
+message UUID {
+  string value = 1;
+}
+
+message Version {
+  string value = 1;
+}
+
+// Auth Types
+message ApiKey {
+  string key = 1;
+}
+
+// GeoJSON Like Types
+message Point {
+  repeated double coordinates = 1;
+}
+
+message MultiPoint {
+  repeated Point coordinates = 1;
+}
+
+message Polygon {
+  repeated Point coordinates = 1;
+}
+
+message MultiPolygon {
+  repeated Polygon coordinates = 2;
+}
+
+enum DataType {
+  DATA_TYPE_UNSPECIFIED = 0;
+  DATA_TYPE_IMAGE = 1;
+  DATA_TYPE_CSV = 2;
+  DATA_TYPE_JSON = 3;
+}

--- a/belifeline/v1/api.proto
+++ b/belifeline/v1/api.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package belifeline.v1;
 
+import "belifeline/models/v1/extinfo.proto";
 import "belifeline/models/v1/koyo.proto";
 import "belifeline/models/v1/provider.proto";
-import "belifeline/models/v1/extinfo.proto";
 import "belifeline/models/v1/types.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
@@ -22,8 +22,8 @@ message KoyoCreateRequest {
   belifeline.models.v1.DataType data_type = 10;
 }
 
-message KoyoCreateResponse{
-  belifeline.models.v1.KoyoInformation koyo_infomation  = 1;
+message KoyoCreateResponse {
+  belifeline.models.v1.KoyoInformation koyo_infomation = 1;
 }
 
 message KoyoInformationCreateOrUpdate {

--- a/belifeline/v1/api.proto
+++ b/belifeline/v1/api.proto
@@ -3,11 +3,13 @@ syntax = "proto3";
 package belifeline.v1;
 
 import "belifeline/models/v1/koyo.proto";
+import "belifeline/models/v1/provider.proto";
+import "belifeline/models/v1/extinfo.proto";
 import "belifeline/models/v1/types.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
-message KoyoInformationCreate {
+message KoyoCreateRequest {
   string koyo_name = 1;
   string koyo_description = 2;
   repeated belifeline.models.v1.UUID need_external = 3;
@@ -18,6 +20,10 @@ message KoyoInformationCreate {
   string license = 8;
   repeated string ext_licenses = 9;
   belifeline.models.v1.DataType data_type = 10;
+}
+
+message KoyoCreateResponse{
+  belifeline.models.v1.KoyoInformation koyo_infomation  = 1;
 }
 
 message KoyoInformationCreateOrUpdate {
@@ -35,7 +41,7 @@ message KoyoInformationCreateOrUpdate {
   belifeline.models.v1.DataType data_type = 12;
 }
 
-message ExternalInformationCreate {
+message ExtInfoCreateRequest {
   string external_name = 1;
   string external_description = 2;
   string license = 3;
@@ -45,8 +51,16 @@ message ExternalInformationCreate {
   repeated string updated_history = 7;
 }
 
+message ExtInfoCreateResponse {
+  belifeline.models.v1.ExternalInformation external_information = 1;
+}
+
 message ClientCreateRequest {
   string username = 1;
+}
+
+message ClientCreateResponse {
+  belifeline.models.v1.ClientData client_data = 1;
 }
 
 enum RequestType {
@@ -55,33 +69,74 @@ enum RequestType {
   REQUEST_TYPE_GEOJSON = 2;
 }
 
-message ListRequest {
+message ClientListRequest {
   int32 limit = 1;
 }
 
-message ClientIdentifier {
+message ClientListResponse {
+  belifeline.models.v1.ClientData client_data = 1;
+}
+
+message ExtInfoListRequest {
+  int32 limit = 1;
+}
+
+message ExtInfoListResponse {
+  belifeline.models.v1.ExternalInformation external_information = 1;
+}
+
+message KoyoListRequest {
+  int32 limit = 1;
+}
+
+message ClientDeleteRequest {
   belifeline.models.v1.UUID client_id = 1;
 }
 
-message ExtInfoIdentifier {
+message ClientDeleteResponse {
+  belifeline.models.v1.UUID client_id = 1;
+}
+
+message ClientRevokeRequest {
+  belifeline.models.v1.UUID client_id = 1;
+}
+
+message ExtInfoDeleteRequest {
   belifeline.models.v1.UUID extinfo_id = 1;
 }
 
-message KoyoIdentifier {
+message ExtInfoDeleteResponse {
+  belifeline.models.v1.UUID extinfo_id = 1;
+}
+
+message KoyoDeleteRequest {
   belifeline.models.v1.UUID koyo_id = 1;
 }
 
-message ApiKeyRevokeRequest {
+message KoyoDeleteResponse {
+  belifeline.models.v1.UUID koyo_id = 1;
+}
+
+message KoyoApiRevokeRequest {
   belifeline.models.v1.UUID koyo_id = 1;
   belifeline.models.v1.ApiKey api_key = 2;
 }
 
-message RevokeResponse {
+message KoyoApiRevokeResponse {
   belifeline.models.v1.UUID koyo_id = 1;
   belifeline.models.v1.ApiKey api_key = 2;
 }
 
-message Empty {}
+message ClientRevokeResponse {
+  belifeline.models.v1.UUID client_id = 1;
+  belifeline.models.v1.ApiKey api_key = 2;
+}
+
+message KoyoListResponse {
+  belifeline.models.v1.KoyoInformation koyo_infomation = 1;
+}
+
+message StatusRequest {}
 
 message StatusResponse {
   string status = 1;

--- a/belifeline/v1/api.proto
+++ b/belifeline/v1/api.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+package belifeline.v1;
+
+import "belifeline/models/v1/koyo.proto";
+import "belifeline/models/v1/types.proto";
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+message KoyoInformationCreate {
+  string koyo_name = 1;
+  string koyo_description = 2;
+  repeated belifeline.models.v1.UUID need_external = 3;
+  map<string, string> koyo_params = 4;
+  repeated float koyo_scales = 5;
+  belifeline.models.v1.Version version = 6;
+  repeated belifeline.models.v1.Version version_history = 7;
+  string license = 8;
+  repeated string ext_licenses = 9;
+  belifeline.models.v1.DataType data_type = 10;
+}
+
+message KoyoInformationCreateOrUpdate {
+  belifeline.models.v1.UUID koyo_id = 1;
+  string koyo_name = 2;
+  string koyo_description = 3;
+  repeated belifeline.models.v1.UUID need_external = 4;
+  map<string, string> koyo_params = 5;
+  repeated float koyo_scales = 6;
+  repeated belifeline.models.v1.UUID koyo_data_ids = 7;
+  belifeline.models.v1.Version version = 8;
+  repeated belifeline.models.v1.Version version_history = 9;
+  string license = 10;
+  repeated string ext_licenses = 11;
+  belifeline.models.v1.DataType data_type = 12;
+}
+
+message ExternalInformationCreate {
+  string external_name = 1;
+  string external_description = 2;
+  string license = 3;
+  string license_description = 4;
+  string first_entry_at = 5;
+  string last_updated_at = 6;
+  repeated string updated_history = 7;
+}
+
+message ClientCreateRequest {
+  string username = 1;
+}
+
+enum RequestType {
+  REQUEST_TYPE_UNSPECIFIED = 0;
+  REQUEST_TYPE_TMS = 1;
+  REQUEST_TYPE_GEOJSON = 2;
+}
+
+message ListRequest {
+  int32 limit = 1;
+}
+
+message ClientIdentifier {
+  belifeline.models.v1.UUID client_id = 1;
+}
+
+message ExtInfoIdentifier {
+  belifeline.models.v1.UUID extinfo_id = 1;
+}
+
+message KoyoIdentifier {
+  belifeline.models.v1.UUID koyo_id = 1;
+}
+
+message ApiKeyRevokeRequest {
+  belifeline.models.v1.UUID koyo_id = 1;
+  belifeline.models.v1.ApiKey api_key = 2;
+}
+
+message RevokeResponse {
+  belifeline.models.v1.UUID koyo_id = 1;
+  belifeline.models.v1.ApiKey api_key = 2;
+}
+
+message Empty {}
+
+message StatusResponse {
+  string status = 1;
+}

--- a/belifeline/v1/api.proto
+++ b/belifeline/v1/api.proto
@@ -6,6 +6,7 @@ import "belifeline/models/v1/extinfo.proto";
 import "belifeline/models/v1/koyo.proto";
 import "belifeline/models/v1/provider.proto";
 import "belifeline/models/v1/types.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
@@ -46,8 +47,8 @@ message ExtInfoCreateRequest {
   string external_description = 2;
   string license = 3;
   string license_description = 4;
-  string first_entry_at = 5;
-  string last_updated_at = 6;
+  google.protobuf.Timestamp first_entry_at = 5;
+  google.protobuf.Timestamp last_updated_at = 6;
   repeated string updated_history = 7;
 }
 

--- a/belifeline/v1/main.proto
+++ b/belifeline/v1/main.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package belifeline.v1;
+
+import "belifeline/models/v1/extinfo.proto";
+import "belifeline/models/v1/koyo.proto";
+import "belifeline/models/v1/provider.proto";
+import "belifeline/models/v1/types.proto";
+import "belifeline/v1/api.proto";
+
+option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
+
+// Service Definitions
+service BeLifelineService {
+  rpc ClientCreate(ClientCreateRequest) returns (belifeline.models.v1.ClientData) {}
+  rpc ClientList(ListRequest) returns (stream belifeline.models.v1.ClientData) {}
+  rpc ClientDelete(ClientIdentifier) returns (ClientIdentifier) {}
+  rpc ClientRevoke(ClientIdentifier) returns (RevokeResponse) {}
+
+  rpc ExtInfoCreate(ExternalInformationCreate) returns (belifeline.models.v1.ExternalInformation) {}
+  rpc ExtInfoList(ListRequest) returns (stream belifeline.models.v1.ExternalInformation) {}
+  rpc ExtInfoDelete(ExtInfoIdentifier) returns (ExtInfoIdentifier) {}
+
+  rpc KoyoCreate(KoyoInformationCreate) returns (belifeline.models.v1.KoyoInformation) {}
+  rpc KoyoList(ListRequest) returns (stream belifeline.models.v1.KoyoInformation) {}
+  rpc KoyoDelete(KoyoIdentifier) returns (KoyoIdentifier) {}
+  rpc KoyoRevoke(ApiKeyRevokeRequest) returns (RevokeResponse) {}
+
+  rpc Status(Empty) returns (StatusResponse) {}
+
+  // Define additional endpoints as appropriate
+}

--- a/belifeline/v1/main.proto
+++ b/belifeline/v1/main.proto
@@ -2,31 +2,27 @@ syntax = "proto3";
 
 package belifeline.v1;
 
-import "belifeline/models/v1/extinfo.proto";
-import "belifeline/models/v1/koyo.proto";
-import "belifeline/models/v1/provider.proto";
-import "belifeline/models/v1/types.proto";
 import "belifeline/v1/api.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
 // Service Definitions
 service BeLifelineService {
-  rpc ClientCreate(ClientCreateRequest) returns (belifeline.models.v1.ClientData) {}
-  rpc ClientList(ListRequest) returns (stream belifeline.models.v1.ClientData) {}
-  rpc ClientDelete(ClientIdentifier) returns (ClientIdentifier) {}
-  rpc ClientRevoke(ClientIdentifier) returns (RevokeResponse) {}
+  rpc ClientCreate(ClientCreateRequest) returns (ClientCreateResponse) {}
+  rpc ClientList(ClientListRequest) returns (stream ClientListResponse) {}
+  rpc ClientDelete(ClientDeleteRequest) returns (ClientDeleteResponse) {}
+  rpc ClientRevoke(ClientRevokeRequest) returns (ClientRevokeResponse) {}
 
-  rpc ExtInfoCreate(ExternalInformationCreate) returns (belifeline.models.v1.ExternalInformation) {}
-  rpc ExtInfoList(ListRequest) returns (stream belifeline.models.v1.ExternalInformation) {}
-  rpc ExtInfoDelete(ExtInfoIdentifier) returns (ExtInfoIdentifier) {}
+  rpc ExtInfoCreate(ExtInfoCreateRequest) returns (ExtInfoCreateResponse) {}
+  rpc ExtInfoList(ExtInfoListRequest) returns (stream ExtInfoListResponse) {}
+  rpc ExtInfoDelete(ExtInfoDeleteRequest) returns (ExtInfoDeleteResponse) {}
 
-  rpc KoyoCreate(KoyoInformationCreate) returns (belifeline.models.v1.KoyoInformation) {}
-  rpc KoyoList(ListRequest) returns (stream belifeline.models.v1.KoyoInformation) {}
-  rpc KoyoDelete(KoyoIdentifier) returns (KoyoIdentifier) {}
-  rpc KoyoRevoke(ApiKeyRevokeRequest) returns (RevokeResponse) {}
+  rpc KoyoCreate(KoyoCreateRequest) returns (KoyoCreateResponse) {}
+  rpc KoyoList(KoyoListRequest) returns (stream KoyoListResponse) {}
+  rpc KoyoDelete(KoyoDeleteRequest) returns (KoyoDeleteResponse) {}
+  rpc KoyoApiRevoke(KoyoApiRevokeRequest) returns (KoyoApiRevokeResponse) {}
 
-  rpc Status(Empty) returns (StatusResponse) {}
+  rpc Status(StatusRequest) returns (StatusResponse) {}
 
   // Define additional endpoints as appropriate
 }


### PR DESCRIPTION
This pull request includes significant updates to the CI workflow and the `belifeline` protobuf models. The changes introduce new protobuf message definitions, service definitions, and updates to the CI configuration.

### CI Workflow

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R23): Added a new CI workflow configuration with jobs for status checks and `buf` linting.

### Protobuf Models

* [`belifeline/models/v1/extinfo.proto`](diffhunk://#diff-89fd8e28c80392b499d70be66f6f36b8bc967e4b31ff9472ec5b3a331b2660fbR1-R25): Added new message definitions for `ExampleInfoExampleData` and `ExternalInformation`.
* [`belifeline/models/v1/koyo.proto`](diffhunk://#diff-ba1ce7761da40a8d05b9d7617ee3d31e612332d8794a33fb1ddae54474a6dee1R1-R41): Added new message definitions for `KoyoData`, `KoyoDataCreate`, and `KoyoInformation`.
* [`belifeline/models/v1/provider.proto`](diffhunk://#diff-dff1ecb10de65b7a3b7c623d765c12acb3b208f22920b043a89ee34796bf05f7R1-R17): Added new message definition for `ClientData`.
* [`belifeline/models/v1/types.proto`](diffhunk://#diff-062ad864a04770c2b9dbb5ce04b5208746fe960551d322c0fff0dc1105939ea7R1-R48): Added new common types including `DateUntil`, `UUID`, `Version`, `ApiKey`, and various GeoJSON-like types.
* [`belifeline/v1/api.proto`](diffhunk://#diff-2f850703d75ac8d4576a483267fa5b62e9b7b575a0bf8f6b229185001fc39653R1-R144): Added new service definitions for `KoyoCreateRequest`, `KoyoCreateResponse`, `KoyoInformationCreateOrUpdate`, `ExtInfoCreateRequest`, `ExtInfoCreateResponse`, `ClientCreateRequest`, `ClientCreateResponse`, and various other request and response messages.
* [`belifeline/v1/main.proto`](diffhunk://#diff-c7981c5e4c48591ed544c02807881a1de19fa883ac3458922036a2dbf99b2d0bR1-R28): Added new service definitions for `BeLifelineService` with RPC methods for client, external information, and Koyo data management.

### OpenAPI Specification

* [`schema/@typespec/openapi3/openapi.v0.1.0.yaml`](diffhunk://#diff-c544f1bfe05543254f8f8b96498ae445f8bc6641d7d82c3fe724c17459f7cc0cL1-L315): Removed the OpenAPI specification for the BeLifeline Server API.
* [`schema/@typespec/openapi3/openapi.yaml`](diffhunk://#diff-67703c70e801aef80638197600285411e3c1699220df434ac618e0af5b8dd00aL1): Removed the reference to the old OpenAPI specification file.