### PR TITLE
fix: remove unused version history field in KoyoInformation message

### DIFF
--- a/belifeline/models/v1/koyo.proto
+++ b/belifeline/models/v1/koyo.proto
@@ -31,7 +31,6 @@ message KoyoInformation {
   repeated float koyo_scales = 6;
   repeated ULID koyo_data_ids = 7;
   Version version = 8;
-  repeated Version version_history = 9;
   string license = 10;
   repeated string ext_licenses = 11;
   DataType data_type = 12;


### PR DESCRIPTION
This pull request includes a change to the `belifeline/models/v1/koyo.proto` file, specifically within the `KoyoInformation` message. The most important change involves the removal of a repeated field.

Changes to `KoyoInformation` message:

* [`belifeline/models/v1/koyo.proto`](diffhunk://#diff-ba1ce7761da40a8d05b9d7617ee3d31e612332d8794a33fb1ddae54474a6dee1L34): Removed the `repeated Version version_history` field from the `KoyoInformation` message.