### PR TITLE
fix: separate koyoset into create and update and separate services

### DIFF
--- a/belifeline/v1/api.proto
+++ b/belifeline/v1/api.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/halcyon-org/kizuna/gen/belifeline/v1;mainv1";
 
-message KoyoSetRequest {
+message KoyoCreateRequest {
   optional belifeline.models.v1.ULID koyo_id = 1;
   string koyo_name = 2;
   string koyo_description = 3;
@@ -24,7 +24,7 @@ message KoyoSetRequest {
   belifeline.models.v1.DataType data_type = 11;
 }
 
-message KoyoSetResponse {
+message KoyoCreateResponse {
   belifeline.models.v1.KoyoInformation koyo_information = 1;
 }
 
@@ -172,4 +172,21 @@ message ExtInfoGetRequest {
 
 message ExtInfoGetResponse {
   bytes data = 1;
+}
+
+message KoyoUpdateRequest {
+  belifeline.models.v1.ULID koyo_id = 1;
+  optional string koyo_name = 2;
+  optional string koyo_description = 3;
+  repeated belifeline.models.v1.ULID need_external = 4;
+  map<string, string> koyo_params = 5;
+  repeated float koyo_scales = 6;
+  belifeline.models.v1.Version version = 7;
+  optional string license = 9;
+  repeated string ext_licenses = 10;
+  optional belifeline.models.v1.DataType data_type = 11;
+}
+
+message KoyoUpdateResponse {
+  belifeline.models.v1.KoyoInformation koyo_information = 1;
 }

--- a/belifeline/v1/main.proto
+++ b/belifeline/v1/main.proto
@@ -19,7 +19,7 @@ service AdminService {
   rpc ExtInfoSet(ExtInfoSetRequest) returns (ExtInfoSetResponse) {}
   rpc ExtInfoDelete(ExtInfoDeleteRequest) returns (ExtInfoDeleteResponse) {}
 
-  rpc KoyoSet(KoyoSetRequest) returns (KoyoSetResponse) {}
+  rpc KoyoCreate(KoyoCreateRequest) returns (KoyoCreateResponse) {}
   rpc KoyoDelete(KoyoDeleteRequest) returns (KoyoDeleteResponse) {}
   rpc KoyoApiRevoke(KoyoApiRevokeRequest) returns (KoyoApiRevokeResponse) {}
 }
@@ -36,5 +36,6 @@ service ExtInfoService {
 }
 
 service KoyoService {
+  rpc KoyoUpdate(KoyoUpdateRequest) returns (KoyoUpdateResponse) {}
   rpc KoyoDataAdd(KoyoDataAddRequest) returns (KoyoDataAddResponse) {}
 }


### PR DESCRIPTION
This pull request includes several changes to the `belifeline/v1/api.proto` and `belifeline/v1/main.proto` files to update the Koyo-related messages and services. The most important changes include renaming existing Koyo messages, adding new Koyo update messages, and updating the service definitions to reflect these changes.

Changes to Koyo messages:

* [`belifeline/v1/api.proto`](diffhunk://#diff-2f850703d75ac8d4576a483267fa5b62e9b7b575a0bf8f6b229185001fc39653L13-R13): Renamed `KoyoSetRequest` to `KoyoCreateRequest` and `KoyoSetResponse` to `KoyoCreateResponse`. [[1]](diffhunk://#diff-2f850703d75ac8d4576a483267fa5b62e9b7b575a0bf8f6b229185001fc39653L13-R13) [[2]](diffhunk://#diff-2f850703d75ac8d4576a483267fa5b62e9b7b575a0bf8f6b229185001fc39653L27-R27)
* [`belifeline/v1/api.proto`](diffhunk://#diff-2f850703d75ac8d4576a483267fa5b62e9b7b575a0bf8f6b229185001fc39653R176-R192): Added new `KoyoUpdateRequest` and `KoyoUpdateResponse` messages to handle updates to Koyo entities.

Updates to service definitions:

* [`belifeline/v1/main.proto`](diffhunk://#diff-c7981c5e4c48591ed544c02807881a1de19fa883ac3458922036a2dbf99b2d0bL22-R22): Updated `AdminService` to use `KoyoCreateRequest` and `KoyoCreateResponse` instead of the old `KoyoSet` messages.
* [`belifeline/v1/main.proto`](diffhunk://#diff-c7981c5e4c48591ed544c02807881a1de19fa883ac3458922036a2dbf99b2d0bR39): Added a new `KoyoUpdate` RPC method to the `KoyoService` to handle the new update functionality.